### PR TITLE
Selective outdated

### DIFF
--- a/src/jarkeeper/statuses.clj
+++ b/src/jarkeeper/statuses.clj
@@ -83,8 +83,16 @@
         (wcar* redis (car/setex k 3600 (if (nil? outdated-info) false outdated-info)))
         outdated-info))))
 
+(defn not-clojure-or-clojurescript?
+  "Takes `dependency` in a format of [foo \"123\"], where foo is a symbol.
+  And verifies if it's Clojure or ClojureScript."
+  [dependency]
+  (nil? (re-matches #"^org.clojure/clojure(script)?$" (str (first dependency)))))
+
 (defn check-deps [redis deps]
-  (map #(conj % (outdated? redis %)) deps))
+  (remove nil? (map #(when (not-clojure-or-clojurescript? %)
+                       (conj % (outdated? redis %)))
+                    deps)))
 
 (defn calculate-stats [deps]
   (let [up-to-date-deps (remove nil? (map (fn [dep] (if (nil? (last dep)) dep nil)) deps))

--- a/test/jarkeeper/statuses_test.clj
+++ b/test/jarkeeper/statuses_test.clj
@@ -74,3 +74,11 @@
   (is (thrown-with-msg? RuntimeException #"EvalReader not allowed when \*read-eval\* is false\."
                         (with-open [rdr (PushbackReader. (io/reader (.getBytes build-boot-eval)))]
                           (read-lein-project (read-file rdr))))))
+
+(deftest not-clojure-or-clojurescript-test
+  (testing "that the dependencies are only true when not Clojure(Script)"
+    (is (= (map #(not-clojure-or-clojurescript? %)
+                '([org.clojure/clojure "1"]
+                  [org.clojure/clojurescript "1"]
+                  [some-jar/foo "2"]))
+           '(false false true)))))

--- a/test/jarkeeper/statuses_test.clj
+++ b/test/jarkeeper/statuses_test.clj
@@ -1,8 +1,11 @@
 (ns jarkeeper.statuses-test
-  (:require [clojure.test :refer :all]
-            [jarkeeper.statuses :refer :all]
-            [clojure.java.io :as io])
-  (:import [java.io PushbackReader]))
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [jarkeeper.statuses :refer [not-clojure-or-clojurescript?
+                                        read-boot-deps
+                                        read-file
+                                        read-lein-project]])
+  (:import java.io.PushbackReader))
 
 (def project-clj-basic "
 (defproject jarkeeper \"0.5.1-SNAPSHOT\"


### PR DESCRIPTION
This commit ignores Clojure(Script) versions when comparing
dependencies.

This is response to the GitHub issue: #8

Some users don't wish to have their versions of Clojure(Script) marked
as outdated, as they might intentionally wish to use that particular
version for their project. And the behaviour up until not was just to
look at the version number and find out if there is a later one, at
which point the project would be marked as having outdated dependency.

This would fix the issue #8 and also the badge for this repo too, as well as ptaoussanis/sente's.