### PR TITLE
Remove repetition for image rendering

### DIFF
--- a/test/jarkeeper/web_test.clj
+++ b/test/jarkeeper/web_test.clj
@@ -1,0 +1,18 @@
+(ns jarkeeper.web-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [jarkeeper.web :refer [img-status-resp last-modified]]
+            [ring.util.response :as resp]))
+
+(deftest image-rendering-test
+  (testing "png image"
+    (is (= (img-status-resp "public/images/out-of-date.png")
+           (-> (resp/resource-response "public/images/out-of-date.png")
+               (resp/header "cache-control" "no-cache")
+               (resp/header "last-modified" (last-modified))
+               (resp/header "content-type" "image/png")))))
+  (testing "svg image"
+    (is (= (img-status-resp "public/images/out-of-date.svg")
+           (-> (resp/resource-response "public/images/out-of-date.svg")
+               (resp/header "cache-control" "no-cache")
+               (resp/header "last-modified" (last-modified))
+               (resp/header "content-type" "image/svg+xml"))))))


### PR DESCRIPTION
There were two functions that were almost identical that did the same
thing: set the correct headers and showed the image.

Replaced it with a single function in order to avoid repetition.